### PR TITLE
Fix schedule annotation alias replacement bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ php:
   - 7.0
   - 5.6
   - 5.5
-  - 5.4
 
 matrix:
   allow_failures:

--- a/src/AppserverIo/Psr/EnterpriseBeans/Annotations/Schedule.php
+++ b/src/AppserverIo/Psr/EnterpriseBeans/Annotations/Schedule.php
@@ -78,10 +78,9 @@ class Schedule extends ReflectionAnnotation
         // set the values found in the annotation
         foreach ($values as $member => $value) {
             // check if we've to replace the value
-            if (array_key_exists($value, $this->aliases)) {
-                $value = $this->aliases[$value];
+            foreach ($this->aliases as $aliasKey => $aliasValue) {
+                $value = str_replace($aliasKey, $aliasValue, $value);
             }
-
             // set the value
             $this->values[$member] = $value;
         }


### PR DESCRIPTION
Use str_replace() to replace occurring alias keywords. This allows more complex cron notations like 'minute = "5, EVERY/10"